### PR TITLE
fix visa_timeout for oscilloscope examples

### DIFF
--- a/Oscilloscopes/Python/RsInstrument/RsInstrument_RTB2000_Example.py
+++ b/Oscilloscopes/Python/RsInstrument/RsInstrument_RTB2000_Example.py
@@ -50,7 +50,7 @@ rtb.query_opc()  # Using *OPC? query waits until all the instrument settings are
 # -----------------------------------------------------------
 # Arming the SCOPE for single acquisition
 # -----------------------------------------------------------
-rtb.VisaTimeout = 2000  # Acquisition timeout - set it higher than the acquisition time
+rtb.visa_timeout = 2000  # Acquisition timeout - set it higher than the acquisition time
 rtb.write_str("SING")
 # -----------------------------------------------------------
 # DUT_Generate_Signal() - in our case we use Probe compensation signal

--- a/Oscilloscopes/Python/RsInstrument/RsInstrument_RTO_Example.py
+++ b/Oscilloscopes/Python/RsInstrument/RsInstrument_RTO_Example.py
@@ -51,7 +51,7 @@ rto.query_opc()  # Using *OPC? query waits until all the instrument settings are
 # -----------------------------------------------------------
 # Arming the rto for single acquisition
 # -----------------------------------------------------------
-rto.VisaTimeout = 2000  # Acquisition timeout - set it higher than the acquisition time
+rto.visa_timeout = 2000  # Acquisition timeout - set it higher than the acquisition time
 rto.write_str("SING")
 # -----------------------------------------------------------
 # DUT_Generate_Signal() - in our case we use Probe compensation signal


### PR DESCRIPTION
Hi, just a little typo in the example scripts! `VisaTimeout` does not exist and doesn't do anything... I did not check other examples, maybe the typo is in there as well...