### PR TITLE
fixing broken remote display update command

### DIFF
--- a/SpectrumAnalyzers/Python/RsInstrument/RsInstrument_FSW_Example.py
+++ b/SpectrumAnalyzers/Python/RsInstrument/RsInstrument_FSW_Example.py
@@ -26,7 +26,7 @@ print(f'SpecAn Options: {",".join(fsw.instrument_options)}')
 fsw.clear_status()
 fsw.reset()
 fsw.write_str('INIT:CONT ON')  # Switch OFF the continuous sweep
-fsw.write_str('SYST:DISPlay:')  # Display update ON - switch OFF after debugging
+fsw.write_str('SYST:DISPlay:UPD ON')  # Display update ON - switch OFF after debugging
 # -----------------------------------------------------------
 # Basic Settings:
 # -----------------------------------------------------------


### PR DESCRIPTION
Driver Version: 1.53.0.96
SpecAn IDN: Rohde&Schwarz,FSW-26,1312.8000K26/10xxxx,5.00SP2
SpecAn Options: K7,K9,K14,K40,K70,B3,B24,B28,B40,B80,B160,B320,U320
Traceback (most recent call last):
  File "verification_standalone.py", line 96, in <module>
    FSW = RohdeSchwarzFSW(debug=True)
  File "verification_standalone.py", line 86, in __init__
    self.fsw.write_str('SYST:DISPlay:')  # Display update ON - switch OFF after debugging
  File "C:\Python37\lib\site-packages\RsInstrument\RsInstrument.py", line 373, in write_str
    self._core.io.write(cmd, log_info='Write string')
  File "C:\Python37\lib\site-packages\RsInstrument\Internal\Instrument.py", line 636, in write
    self.check_status()
  File "C:\Python37\lib\site-packages\RsInstrument\Internal\Instrument.py", line 573, in check_status
    assert_no_instrument_status_errors(self.resource_name, errors)
  File "C:\Python37\lib\site-packages\RsInstrument\Internal\InstrumentErrors.py", line 72, in assert_no_instrument_status_errors
    raise StatusException(rsrc_name, msg, errors, first_exc=first_exc)

`RsInstrument.Internal.InstrumentErrors.StatusException: 'TCPIP::192.168.0.184::INSTR': Instrument error detected: -113,"Undefined header;SYST:DISPlay:"`