### PR TITLE
Code refactoring (HMC8012 example)

### DIFF
--- a/Misc/Python/RsInstrument/RsInstrument_HMC8012_measurement_logging_filetransfer.py
+++ b/Misc/Python/RsInstrument/RsInstrument_HMC8012_measurement_logging_filetransfer.py
@@ -5,8 +5,8 @@
 Created on 2023/01
 
 Author: Customer Support / PJ
-Version Number: 1
-Date of last change: 2023/01/05
+Version Number: 2
+Date of last change: 2023/02/05
 Requires: HMC8012, FW 1.400 or newer and eventually adequate options
 - Installed RsInstrument Python module 1.53.0 or newer
 - Installed VISA e.g. R&S Visa 5.12.x or newer
@@ -25,16 +25,16 @@ Please find more information about RsInstrument at
 https://rsinstrument.readthedocs.io/en/latest/
 """
 
-# --> Import necessary packets  
-from RsInstrument import *
+# --> Import necessary packets
+import os
 from time import sleep
-
+from RsInstrument import RsInstrument, TimeoutException
 
 # Define variables
 resource = 'TCPIP::10.205.0.218::INSTR'  # VISA resource string for the device
-logdur = 5  # Log time in seconds
+log_dur = 5  # Log time in seconds
 log_file_name = 'TEST.CSV'  # Name of the HMC log file
-pcFilePath = r'c:\Tempdata\logdata.csv'  # Name and Path of the PC log file
+pc_log_file_name = r'c:\Tempdata\logdata.csv'  # Name and Path of the PC log file
 
 # Control the device via RsVISA
 hmc8012 = RsInstrument(resource, reset=True, id_query=True, options="SelectVisa='rs', AddTermCharToWriteBinData = OFF, "
@@ -45,87 +45,135 @@ hmc8012 = RsInstrument(resource, reset=True, id_query=True, options="SelectVisa=
                                                                     "VisaTimeout = 10000, OpcTimeout = 10000")
 
 
-def comprep():
-    """Preparation of the communication (termination, etc...)"""
-
+def com_prep() -> None:
+    """Prepare the communication (termination, etc.)."""
     RsInstrument.assert_minimum_version('1.53.0')
-    print(f'VISA Manufacturer: {hmc8012.visa_manufacturer}')  # Confirm VISA package to be chosen
+    # Confirm VISA package to be chosen
+    print(f'VISA Manufacturer: {hmc8012.visa_manufacturer}')
     hmc8012.clear_status()  # Clear status register
-  
-    
-def close():
-    """Close the VISA session"""
-    
+
+
+def close() -> None:
+    """
+    Close the VISA session.
+
+    :return: None
+    """
     hmc8012.close()
 
 
-def comcheck():
-    """Check communication with the device"""
+def com_check() -> None:
+    """
+    Check communication with the device.
 
-    idnresponse = hmc8012.query_str('*IDN?')  # Check for instrument to be present
-    print('Hello, I am ' + idnresponse + '\n')
-    
-   
-def measprep():
-    """Prepare instrument for desired measurement
-    In this case setting an adequate DC Voltage range and set ADC rate to maximum"""
-
-    hmc8012.write_str('CONF:VOLT:DC 400mV')  # DC Voltage range to 400mV
-    hmc8012.write_str('SENSe:ADCRate FAST')  # ADC rate to Fast mode
+    :return: None
+    """
+    # Check for instrument to be present
+    print(f'Hello, I am {hmc8012.query_str_with_opc("*IDN?")}\n')
 
 
-def logsetup():
-    """Prepare and begin logging, in addition check the directory if the file exists
-     after logging process is complete."""
+def meas_prep() -> None:
+    """
+    Prepare instrument for desired measurement
+    In this case setting an adequate DC Voltage range and set ADC rate to maximum
+
+    :return: None
+    """
+    hmc8012.write_str_with_opc(
+        'CONF:VOLT:DC 400mV')  # DC Voltage range to 400mV
+    hmc8012.write_str_with_opc('SENSe:ADCRate FAST')  # ADC rate to Fast mode
+
+
+def log_setup(log_duration: int, log_file_name: str, log_format: str = 'CSV') -> None:   
+    """
+    Prepare and begin logging, in addition check the directory if the file exists
+    after logging process is complete.
+
+    :param log_duration: Log duration in seconds
+    :param log_file_name: Name of the log file on the HMC8012
+    :param log_format: Log file format, default is CSV
+    :return: None
+    :raises IOError: If the log file to be deleted is not present
+    :raises TimeoutException: If the timeout is reached
+    """
 
     # Delete the log file (if already existing) and insert a try block to prevent
     # throwing an error when the log file to be deleted is not present
     try:
-        fileresponse = hmc8012.query_str('DATA:LIST? INT')  # Read out directory before logging (only for information)
-        print('Content of the directory at the start is' + fileresponse)
-        hmc8012.write_str_with_opc(f'DATA:DELETE "{log_file_name}",INT')  # Delete the logfile if already present
+        # Read out directory before logging (only for information)
+        print(
+            f'Content of the directory at the start is {hmc8012.query_str_list_with_opc("DATA:LIST? INT")}')
+        # Delete the logfile if already present
+        hmc8012.write_str_with_opc(f'DATA:DELETE "{log_file_name}",INT')
     except IOError:
-        pass
+        print('An IOError occurred while deleting the log file, continuing anyway.')
+    except TimeoutException:
+        print('Timeout occurred while deleting the log file, continuing anyway.')
 
     # hmc8012.query_opc()
 
-    hmc8012.write_str('DATA:LOG:MODE TIME')  # Log mode is set to time mode
-    hmc8012.write_str('DATA:LOG:TIME ' + str(logdur))  # Set logging duration time (logdur) in seconds
-    hmc8012.write_str('DATA:LOG:INTerval 0')  # Set minimal interval time (0) between the logging steps
+    # Log mode is set to time mode
+    hmc8012.write_str_with_opc('DATA:LOG:MODE TIME')
+    # Set logging duration time (log_duration) in seconds
+    hmc8012.write_str_with_opc(f'DATA:LOG:TIME {log_duration}')
+    # Set minimal interval time (0) between the logging steps
+    hmc8012.write_str_with_opc('DATA:LOG:INTerval 0')
 
-    hmc8012.write_str('DATA:LOG:FORMAT CSV')  # CSV is log file format
-    hmc8012.write_str('DATA:LOG:FNAME "' + log_file_name + '", INT')  # Define Log file name
-    print('Log File Name now is', hmc8012.query('DATA:LOG:FNAME?'))
+    # CSV is log file format
+    hmc8012.write_str_with_opc(f'DATA:LOG:FORMAT {log_format}')
+    hmc8012.write_str_with_opc('DATA:LOG:FNAME "' + log_file_name +
+                               '", INT')  # Define Log file name
+    print(f'Log File Name now is {hmc8012.query("DATA:LOG:FNAME?")}')
     hmc8012.query_opc()  # Check for command completion
 
     hmc8012.write_str_with_opc('DATA:LOG:STATe ON ')  # Activate logging
-    print('Logging runs now for ' + str(logdur) + ' seconds - please wait!\n')
-    sleep(int(logdur+5))  # Wait for the log to be written and add five seconds for logging to be completed
+    print(f'Logging runs now for {log_duration} seconds - please wait!\n')
+    # Wait for the log to be written and add five seconds for logging to be completed
+    sleep(int(log_duration + 5))
 
 
-def fileget():
-    """Transfer the log file to the local PC"""
+def file_get(log_file_name: str, pc_log_file_name: str, delete_log_file: bool = True) -> None:
+    """
+    Transfer the log file to the local PC.
+
+    :param log_file_name: Name of the log file on the HMC8012
+    :param pc_log_file_name: Name and path of the log file on the PC
+    :param delete_log_file: Delete the log file on the HMC8012 after transfer
+    :return: None
+    """
     print('Now transferring the log file...\n')
     hmc8012.visa_timeout = 10000  # Enlarge timeout value for VISA Read Operations
-    hmc8012.get_session_handle().read_termination = ""  # Disable to process read termination characters
-    logdata = hmc8012.query_str_with_opc(f'DATA:DATA? "{log_file_name}",INT')  # Query data into a string
-    file = open(pcFilePath, 'w')  # Open the PC log file in write mode
-    file.write(logdata)  # And write this string into the PC log file
-    file.close()  # Close the PC log file
-    hmc8012.get_session_handle().read_termination = "\n"  # Switch back to process read termination character "\n"
-    print(f'File saved to {pcFilePath}')
-    hmc8012.write_str_with_opc(f'DATA:DELETE "{log_file_name}",INT')
-    hmc8012.visa_timeout = 5000  # Set back to original timeout value for VISA Read Operations
+    # Disable to process read termination characters
+    hmc8012.get_session_handle().read_termination = ""
+    # Query data into a string
+    log_data = hmc8012.query_str_with_opc(
+        f'DATA:DATA? "{log_file_name}",INT')
+    # Ensure that the path to the file exists
+    os.makedirs(os.path.dirname(pc_log_file_name), exist_ok=True)
+    # Open the PC log file in write mode,
+    # write the string into the file and close the file
+    open(pc_log_file_name, 'w').write(log_data)
+    # Switch back to process read termination character "\n"
+    hmc8012.get_session_handle().read_termination = "\n"
+    print(f'File saved locally to {pc_log_file_name}')
+
+    if delete_log_file:
+        # Delete the log file from the HMC8012
+        hmc8012.write_str_with_opc(f'DATA:DELETE "{log_file_name}",INT')
+
+    # Set back to original timeout value for VISA Read Operations
+    hmc8012.visa_timeout = 5000
 
 
 # Main Program begins here
+if __name__ == '__main__':
+    print("Program started.")
 
-comprep()
-comcheck()
-measprep()
-logsetup()
-fileget()
-close()
+    com_prep()
+    com_check()
+    meas_prep()
+    log_setup(log_duration=log_dur, log_file_name=log_file_name)
+    file_get(log_file_name=log_file_name, pc_log_file_name=pc_log_file_name)
+    close()
 
-
-print("Program successfully ended.")
+    print("Program successfully ended.")


### PR DESCRIPTION
Hi,

I've just got my hands on a HMC8012 for a small project and I wanted to use Python to collect the data. I was happy to find this example, however, I had/have some troubles and questions.

First, the example was not running directly, I had an uncaught `TimeoutException` in the `try`, `except` block. The block can catch `IOError` which for me seems a bit odd (I do not grasp how that kind of error can occur).

Second, the default path on the computer for the log file does not exist on every computer. Thus, the script crashes because of the missing path. So I implemented a way to automatically create the path.

Third, I don't know if it makes sense to use `write_str()` instead of `write_str_with_opc()`. Isn't `write_str_with_opc()` better to ensure that the commands are well received? Or did I misunderstand something about the OPC?

Fourth, I've added parameters to the function. I generally prefer to avoid the usage of global variable in the code. Well, I've left the instrument global variable, but looking at the example, I wonder if creating an instrument class wouldn't be cleaner. It's mostly an aesthetic consideration.

Fifth, **the script only works one or two times in a row, then, the HMC8012 behave weirdly, either, it cannot create the file internally**, or it doesn't start the sample (the counter stays stuck at 0). Well, for the second behaviour, I wonder if it did not occur when trying to measure a current with an erroneous range of 400 mA instead of 200 mA.

Best,
Vincent

P.S.: I need to retest the code, since I modified it Friday with the tool in front of me, then today, only with Copilot (so the code, might need some debug).